### PR TITLE
update example

### DIFF
--- a/compute/hello-world.py
+++ b/compute/hello-world.py
@@ -1,5 +1,5 @@
 import os
-
+import time
 import dotenv
 import swan
 
@@ -9,13 +9,21 @@ def hello_world():
     orchestrator = swan.resource(api_key=os.getenv("SWAN_API_KEY"), network='mainnet',service_name='Orchestrator')
 
     result = orchestrator.create_task(
-        app_repo_image='hello_world',
+        repo_uri='https://github.com/swanchain/awesome-swanchain/tree/main/hello_world',
         wallet_address=os.getenv("WALLET_ADDRESS"),
         private_key=os.getenv("PRIVATE_KEY"),
+        instance_type='C1ae.small',
+        auto_pay=True
     )
     task_uuid = result['id']
     task_info = orchestrator.get_deployment_info(task_uuid=task_uuid)
     print(task_info)
+
+    # Wait for the task to be deployed
+    time.sleep(30)
+    # Show deployed application URLs
+    app_urls = orchestrator.get_real_url(task_uuid=task_uuid)
+    print(f"App URLs: {app_urls}")
 
 if __name__ == "__main__":
     # Load environment variables from the .env file

--- a/compute/hello-world.py
+++ b/compute/hello-world.py
@@ -39,7 +39,7 @@ class HelloWorld:
         async def wait_for_url(url):
             start_time = time.time()
             async with aiohttp.ClientSession() as session:
-                # 5 minutes for hello world
+                # after 5 minutes, assume app url is not running
                 while time.time() - start_time < 300:
                     async with session.get(url) as resp:
                         if resp.status == 200:

--- a/compute/hello-world.py
+++ b/compute/hello-world.py
@@ -39,7 +39,8 @@ class HelloWorld:
         async def wait_for_url(url):
             start_time = time.time()
             async with aiohttp.ClientSession() as session:
-                while time.time() - start_time < 300:    # 5 minutes
+                # 5 minutes for hello world
+                while time.time() - start_time < 300:
                     async with session.get(url) as resp:
                         if resp.status == 200:
                             logging.info(f"App is running at {url}")

--- a/compute/hello-world.py
+++ b/compute/hello-world.py
@@ -2,30 +2,61 @@ import os
 import time
 import dotenv
 import swan
+import logging
+import asyncio
+import aiohttp
 
+class HelloWorld:
+    def __init__(self):
+        self.orchestrator = swan.resource(
+            api_key=os.getenv("SWAN_API_KEY"), 
+            network='testnet',
+            service_name='Orchestrator'
+        )
+            
+    def deploy(self):
+        result = self.orchestrator.create_task(
+            repo_uri='https://github.com/swanchain/awesome-swanchain/tree/main/hello_world',
+            wallet_address=os.getenv("WALLET_ADDRESS"),
+            private_key=os.getenv("PRIVATE_KEY"),
+            instance_type='C1ae.small',
+            auto_pay=True
+        )
+        self.task_uuid = result['task_uuid']
+        task_info = self.orchestrator.get_deployment_info(task_uuid=self.task_uuid)
+        logging.info(task_info)
 
+    def wait_for_running(self):
+        # wait for app URLs be generated
+        app_urls = []
+        while True:
+            time.sleep(5)
+            if app_urls := self.orchestrator.get_real_url(task_uuid=self.task_uuid):
+                logging.info(f"App will be running at {app_urls}")
+                break
+        
+        # wait for app to be running
+        async def wait_for_url(url):
+            start_time = time.time()
+            async with aiohttp.ClientSession() as session:
+                while time.time() - start_time < 300:    # 5 minutes
+                    async with session.get(url) as resp:
+                        if resp.status == 200:
+                            logging.info(f"App is running at {url}")
+                            logging.info(f"Response: {await resp.text()}")
+                            break
+                        await asyncio.sleep(5)
+                else:
+                    logging.warning(f"App is not running at {url} after 5 minutes")
 
-def hello_world():
-    orchestrator = swan.resource(api_key=os.getenv("SWAN_API_KEY"), network='mainnet',service_name='Orchestrator')
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(asyncio.gather(*[wait_for_url(url) for url in app_urls]))
 
-    result = orchestrator.create_task(
-        repo_uri='https://github.com/swanchain/awesome-swanchain/tree/main/hello_world',
-        wallet_address=os.getenv("WALLET_ADDRESS"),
-        private_key=os.getenv("PRIVATE_KEY"),
-        instance_type='C1ae.small',
-        auto_pay=True
-    )
-    task_uuid = result['id']
-    task_info = orchestrator.get_deployment_info(task_uuid=task_uuid)
-    print(task_info)
-
-    # Wait for the task to be deployed
-    time.sleep(30)
-    # Show deployed application URLs
-    app_urls = orchestrator.get_real_url(task_uuid=task_uuid)
-    print(f"App URLs: {app_urls}")
 
 if __name__ == "__main__":
     # Load environment variables from the .env file
     dotenv.load_dotenv("../.env")
-    hello_world()
+
+    hello_world = HelloWorld()
+    hello_world.deploy()
+    hello_world.wait_for_running()


### PR DESCRIPTION
- update example to use `repo_uri`, which is the main parameter for developer use (instead of necessity to explain where to get `app_repo_image`)
- add `instance_type` parameter (although it has default setting `C1ae.small`, it won't hurt to let developer know this parameter is key to create task)
- add logic to get deployed application URLs, thus developer can get access to what he deploys